### PR TITLE
Refactor path handling in update-global-mcp.js

### DIFF
--- a/update-global-mcp.js
+++ b/update-global-mcp.js
@@ -2,11 +2,24 @@
 
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 
 // Load configurations
-const globalConfigPath = '/home/coder/.claude.json';
-const projectConfigPath = '/home/coder/project/mcp-servers-config/.mcp.json';
-const envPath = '/home/coder/project/mcp-servers-config/.env';
+const globalConfigPath = path.join(os.homedir(), '.claude.json');
+const projectConfigPath = path.join(process.cwd(), '.mcp.json');
+const envPath = path.join(process.cwd(), '.env');
+
+// Ensure required files exist
+function ensureExists(filePath, description) {
+    if (!fs.existsSync(filePath)) {
+        console.error(`❌ ${description} not found at ${filePath}`);
+        process.exit(1);
+    }
+}
+
+ensureExists(globalConfigPath, 'Global config');
+ensureExists(projectConfigPath, 'Project config');
+ensureExists(envPath, '.env file');
 
 console.log('🔧 Updating global Claude MCP configuration...');
 


### PR DESCRIPTION
## Summary
- derive config paths from home and current directory using `path.join`
- add file existence checks to fail fast when required config files are missing

## Testing
- `node update-global-mcp.js`
- `mv .env .env.bak && node update-global-mcp.js` *(fails: `.env` file not found)*
- `pre-commit run --files update-global-mcp.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c94f1c608326add4e411224f1f22