### PR TITLE
Remove sudo from Dockerfile RUN instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM codercom/code-server:latest  # Use your current image/tag from Coolify
 
 # Install Node.js, Claude Code CLI (supersedes your manual install), and utils
-RUN sudo apt-get update && sudo apt-get install -y nodejs npm tree \
+RUN apt-get update && apt-get install -y nodejs npm tree \
     && npm install -g @anthropic-ai/claude-code \
     && echo 'alias ll="ls -la"' >> /home/coder/.bashrc
 


### PR DESCRIPTION
## Summary
- remove sudo prefix from Dockerfile RUN layer
- consolidate apt-get update and install commands

## Testing
- `docker build -t mcp-servers-config-test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c95985b8832692266cfaa0f870c3