### PR TITLE
chore: move example workflow to examples directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ claude
 - [Compatibility](docs/compatibility.md)
 - [Security Best Practices](docs/security.md)
 - [Additional Resources](docs/additional-resources.md)
+- [Example Workflows](examples/README.md) *(placeholder data only)*
 - [Contributing](CONTRIBUTING.md)
 
 ## 📄 License

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Example Workflows
+
+These workflows demonstrate how to configure or extend the MCP servers. **All data is placeholder only** and must be replaced with your own values before use in any production environment.

--- a/examples/irish-business-ai-workflow.json
+++ b/examples/irish-business-ai-workflow.json
@@ -1,4 +1,5 @@
 {
+  "description": "Example workflow with placeholder data. Replace placeholders before use.",
   "name": "Irish Business Data Scraper with AI Analysis",
   "nodes": [
     {


### PR DESCRIPTION
## Summary
- relocate `irish-business-ai-workflow.json` into new `examples/` directory
- document placeholder nature of examples and link from README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68a3d5d5436c832682cd2384e6ae5198