### PR TITLE
refactor: centralize server launching logic

### DIFF
--- a/mcp-servers/brave-search-mcp/index.js
+++ b/mcp-servers/brave-search-mcp/index.js
@@ -1,120 +1,66 @@
 #!/usr/bin/env node
 
-const { spawn } = require('child_process');
-const yargs = require('yargs/yargs');
-const { hideBin } = require('yargs/helpers');
+const { parseArgs, launch } = require('../common/launcher');
 
-// Parse command line arguments
-const argv = yargs(hideBin(process.argv))
-  .option('api-key', {
-    type: 'string',
-    description: 'Brave Search API key',
-    alias: 'k'
-  })
-  .option('transport', {
-    type: 'string',
-    description: 'Transport mode (stdio or http)',
-    choices: ['stdio', 'http'],
-    default: 'stdio',
-    alias: 't'
-  })
-  .option('port', {
-    type: 'number',
-    description: 'HTTP server port (when using http transport)',
-    default: 8080,
-    alias: 'p'
-  })
-  .option('host', {
-    type: 'string',
-    description: 'HTTP server host (when using http transport)',
-    default: '0.0.0.0',
-    alias: 'h'
-  })
-  .help()
-  .alias('help', 'help')
-  .parse();
+const argv = parseArgs((yargs) =>
+  yargs
+    .option('api-key', {
+      type: 'string',
+      description: 'Brave Search API key',
+      alias: 'k'
+    })
+    .option('transport', {
+      type: 'string',
+      description: 'Transport mode (stdio or http)',
+      choices: ['stdio', 'http'],
+      default: 'stdio',
+      alias: 't'
+    })
+    .option('port', {
+      type: 'number',
+      description: 'HTTP server port (when using http transport)',
+      default: 8080,
+      alias: 'p'
+    })
+    .option('host', {
+      type: 'string',
+      description: 'HTTP server host (when using http transport)',
+      default: '0.0.0.0',
+      alias: 'h'
+    })
+);
 
-class BraveSearchMCPProxy {
-  constructor() {
-    this.apiKey = argv.apiKey || process.env.BRAVE_API_KEY;
-    this.transport = argv.transport || process.env.BRAVE_MCP_TRANSPORT || 'stdio';
-    this.port = argv.port || process.env.BRAVE_MCP_PORT || 8080;
-    this.host = argv.host || process.env.BRAVE_MCP_HOST || '0.0.0.0';
-  }
+const apiKey = argv.apiKey || process.env.BRAVE_API_KEY;
+const transport = argv.transport || process.env.BRAVE_MCP_TRANSPORT || 'stdio';
+const port = argv.port || process.env.BRAVE_MCP_PORT || 8080;
+const host = argv.host || process.env.BRAVE_MCP_HOST || '0.0.0.0';
 
-  async run() {
-    // Check if API key is provided
-    if (!this.apiKey) {
-      console.error('Error: Brave Search API key is required.');
-      console.error('Set BRAVE_API_KEY environment variable or use --api-key flag');
-      console.error('');
-      console.error('To get an API key:');
-      console.error('1. Sign up at https://brave.com/search/api/');
-      console.error('2. Generate your API key from the developer dashboard');
-      console.error('3. Set the key as an environment variable or pass it with --api-key');
-      process.exit(1);
-    }
-
-    // Start the Brave Search MCP server using npx
-    console.error('Starting Brave Search MCP Server...');
-    
-    const args = ['-y', '@brave/brave-search-mcp-server'];
-    
-    // Add transport-specific arguments
-    if (this.transport === 'http') {
-      args.push('--transport', 'http', '--port', this.port.toString(), '--host', this.host);
-    } else {
-      args.push('--transport', 'stdio');
-    }
-
-    const npx = spawn('npx', args, {
-      stdio: ['inherit', 'inherit', 'inherit'],
-      env: {
-        ...process.env,
-        BRAVE_API_KEY: this.apiKey,
-        BRAVE_MCP_TRANSPORT: this.transport,
-        BRAVE_MCP_PORT: this.port.toString(),
-        BRAVE_MCP_HOST: this.host
-      }
-    });
-
-    // Handle graceful shutdown
-    process.on('SIGINT', () => {
-      console.error('Shutting down Brave Search MCP Server...');
-      npx.kill('SIGTERM');
-      process.exit(0);
-    });
-
-    process.on('SIGTERM', () => {
-      console.error('Shutting down Brave Search MCP Server...');
-      npx.kill('SIGTERM');
-      process.exit(0);
-    });
-
-    npx.on('close', (code) => {
-      if (code !== 0 && code !== null) {
-        console.error(`Brave Search MCP Server exited with code ${code}`);
-        process.exit(code);
-      }
-    });
-
-    npx.on('error', (error) => {
-      console.error('Error starting Brave Search MCP Server:', error.message);
-      console.error('Make sure npm/npx is installed and accessible in your PATH');
-      process.exit(1);
-    });
-  }
+if (!apiKey) {
+  console.error('Error: Brave Search API key is required.');
+  console.error('Set BRAVE_API_KEY environment variable or use --api-key flag');
+  console.error('');
+  console.error('To get an API key:');
+  console.error('1. Sign up at https://brave.com/search/api/');
+  console.error('2. Generate your API key from the developer dashboard');
+  console.error('3. Set the key as an environment variable or pass it with --api-key');
+  process.exit(1);
 }
 
-// Error handling
-process.on('unhandledRejection', (reason, promise) => {
-  console.error('Unhandled rejection at:', promise, 'reason:', reason);
-  process.exit(1);
-});
+const args = ['-y', '@brave/brave-search-mcp-server'];
 
-// Start proxy server
-const proxy = new BraveSearchMCPProxy();
-proxy.run().catch((error) => {
-  console.error('Failed to start Brave Search MCP proxy:', error.message);
-  process.exit(1);
+if (transport === 'http') {
+  args.push('--transport', 'http', '--port', port.toString(), '--host', host);
+} else {
+  args.push('--transport', 'stdio');
+}
+
+launch('npx', args, {
+  env: {
+    ...process.env,
+    BRAVE_API_KEY: apiKey,
+    BRAVE_MCP_TRANSPORT: transport,
+    BRAVE_MCP_PORT: port.toString(),
+    BRAVE_MCP_HOST: host
+  },
+  serverName: 'Brave Search MCP Server'
 });

--- a/mcp-servers/common/launcher.js
+++ b/mcp-servers/common/launcher.js
@@ -1,0 +1,52 @@
+const { spawn } = require('child_process');
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled rejection at:', promise, 'reason:', reason);
+  process.exit(1);
+});
+
+function parseArgs(builder) {
+  return builder(yargs(hideBin(process.argv)))
+    .help()
+    .alias('help', 'h')
+    .parse();
+}
+
+function launch(command, args, { env = process.env, serverName = 'MCP Server', onError, spawnOptions = {} } = {}) {
+  const child = spawn(command, args, {
+    stdio: ['inherit', 'inherit', 'inherit'],
+    env,
+    ...spawnOptions
+  });
+
+  function shutdown() {
+    console.error(`Shutting down ${serverName}...`);
+    child.kill('SIGTERM');
+    process.exit(0);
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  child.on('close', (code) => {
+    if (code !== 0 && code !== null) {
+      console.error(`${serverName} exited with code ${code}`);
+      process.exit(code);
+    }
+  });
+
+  child.on('error', (error) => {
+    if (onError) {
+      onError(error);
+    } else {
+      console.error(`Error starting ${serverName}:`, error.message);
+    }
+    process.exit(1);
+  });
+
+  return child;
+}
+
+module.exports = { parseArgs, launch };

--- a/mcp-servers/fetch-mcp/index.js
+++ b/mcp-servers/fetch-mcp/index.js
@@ -1,41 +1,38 @@
 #!/usr/bin/env node
 
 const { spawn } = require('child_process');
-const yargs = require('yargs/yargs');
-const { hideBin } = require('yargs/helpers');
+const { parseArgs, launch } = require('../common/launcher');
 
-// Parse command line arguments
-const argv = yargs(hideBin(process.argv))
-  .option('ignore-robots-txt', {
-    type: 'boolean',
-    description: 'Ignore robots.txt restrictions',
-    default: false
-  })
-  .option('user-agent', {
-    type: 'string',
-    description: 'Custom user agent string',
-    alias: 'ua'
-  })
-  .option('proxy-url', {
-    type: 'string',
-    description: 'Proxy URL for requests',
-    alias: 'proxy'
-  })
-  .option('timeout', {
-    type: 'number',
-    description: 'Request timeout in seconds',
-    default: 30
-  })
-  .option('method', {
-    type: 'string',
-    description: 'Preferred installation method (uvx, docker, npx)',
-    choices: ['uvx', 'docker', 'npx'],
-    default: 'uvx',
-    alias: 'm'
-  })
-  .help()
-  .alias('help', 'h')
-  .parse();
+const argv = parseArgs((yargs) =>
+  yargs
+    .option('ignore-robots-txt', {
+      type: 'boolean',
+      description: 'Ignore robots.txt restrictions',
+      default: false
+    })
+    .option('user-agent', {
+      type: 'string',
+      description: 'Custom user agent string',
+      alias: 'ua'
+    })
+    .option('proxy-url', {
+      type: 'string',
+      description: 'Proxy URL for requests',
+      alias: 'proxy'
+    })
+    .option('timeout', {
+      type: 'number',
+      description: 'Request timeout in seconds',
+      default: 30
+    })
+    .option('method', {
+      type: 'string',
+      description: 'Preferred installation method (uvx, docker, npx)',
+      choices: ['uvx', 'docker', 'npx'],
+      default: 'uvx',
+      alias: 'm'
+    })
+);
 
 class FetchMCPProxy {
   constructor() {
@@ -50,7 +47,7 @@ class FetchMCPProxy {
     return new Promise((resolve) => {
       const command = method === 'docker' ? 'docker' : method;
       const args = method === 'docker' ? ['--version'] : ['--version'];
-      
+
       const process = spawn(command, args, { stdio: 'pipe' });
       process.on('close', (code) => {
         resolve(code === 0);
@@ -63,7 +60,7 @@ class FetchMCPProxy {
 
   async findAvailableMethod() {
     const methods = ['uvx', 'docker', 'npx'];
-    
+
     for (const method of methods) {
       const available = await this.checkMethodAvailability(method);
       if (available) {
@@ -71,36 +68,35 @@ class FetchMCPProxy {
         return method;
       }
     }
-    
+
     throw new Error('None of the required tools (uvx, docker, npx) are available');
   }
 
   buildArgs() {
     const args = [];
-    
+
     if (this.ignoreRobotsTxt) {
       args.push('--ignore-robots-txt');
     }
-    
+
     if (this.userAgent) {
       args.push('--user-agent', this.userAgent);
     }
-    
+
     if (this.proxyUrl) {
       args.push('--proxy-url', this.proxyUrl);
     }
-    
+
     if (this.timeout && this.timeout !== 30) {
       args.push('--timeout', this.timeout.toString());
     }
-    
+
     return args;
   }
 
   async run() {
     let method = this.method;
-    
-    // Check if the preferred method is available, otherwise find an available one
+
     const methodAvailable = await this.checkMethodAvailability(method);
     if (!methodAvailable) {
       console.error(`Warning: Preferred method '${method}' is not available, searching for alternatives...`);
@@ -108,21 +104,20 @@ class FetchMCPProxy {
     }
 
     console.error('Starting Fetch MCP Server...');
-    
+
     let command, args, env;
-    
+
     switch (method) {
       case 'uvx':
         command = 'uvx';
         args = ['mcp-server-fetch', ...this.buildArgs()];
         env = process.env;
         break;
-        
+
       case 'docker':
         command = 'docker';
         args = ['run', '-i', '--rm'];
-        
-        // Add environment variables for Docker
+
         if (this.ignoreRobotsTxt) {
           args.push('-e', 'IGNORE_ROBOTS_TXT=true');
         }
@@ -132,64 +127,35 @@ class FetchMCPProxy {
         if (this.proxyUrl) {
           args.push('-e', `PROXY_URL=${this.proxyUrl}`);
         }
-        
+
         args.push('mcp/fetch', ...this.buildArgs());
         env = process.env;
         break;
-        
+
       case 'npx':
         command = 'npx';
         args = ['-y', 'mcp-server-fetch', ...this.buildArgs()];
         env = process.env;
         break;
-        
+
       default:
         throw new Error(`Unsupported method: ${method}`);
     }
 
-    const server = spawn(command, args, {
-      stdio: ['inherit', 'inherit', 'inherit'],
-      env: env
-    });
-
-    // Handle graceful shutdown
-    process.on('SIGINT', () => {
-      console.error('Shutting down Fetch MCP Server...');
-      server.kill('SIGTERM');
-      process.exit(0);
-    });
-
-    process.on('SIGTERM', () => {
-      console.error('Shutting down Fetch MCP Server...');
-      server.kill('SIGTERM');
-      process.exit(0);
-    });
-
-    server.on('close', (code) => {
-      if (code !== 0 && code !== null) {
-        console.error(`Fetch MCP Server exited with code ${code}`);
-        process.exit(code);
+    launch(command, args, {
+      env,
+      serverName: 'Fetch MCP Server',
+      onError: (error) => {
+        console.error('Error starting Fetch MCP Server:', error.message);
+        console.error('Please ensure the required tools are installed:');
+        console.error('- For uvx: pip install uv');
+        console.error('- For docker: https://docs.docker.com/get-docker/');
+        console.error('- For npx: npm install -g npm');
       }
-    });
-
-    server.on('error', (error) => {
-      console.error('Error starting Fetch MCP Server:', error.message);
-      console.error('Please ensure the required tools are installed:');
-      console.error('- For uvx: pip install uv');
-      console.error('- For docker: https://docs.docker.com/get-docker/');
-      console.error('- For npx: npm install -g npm');
-      process.exit(1);
     });
   }
 }
 
-// Error handling
-process.on('unhandledRejection', (reason, promise) => {
-  console.error('Unhandled rejection at:', promise, 'reason:', reason);
-  process.exit(1);
-});
-
-// Start proxy server
 const proxy = new FetchMCPProxy();
 proxy.run().catch((error) => {
   console.error('Failed to start Fetch MCP proxy:', error.message);


### PR DESCRIPTION
## Summary
- add shared launcher utility for argument parsing, process spawning, and signal handling
- refactor brave-search, fetch, notion, github, everything, and slack MCP servers to use shared launcher

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c60d4880d08326b35a5247e4c91a2b