### PR TITLE
Add Jest configuration tests for MCP servers

### DIFF
--- a/mcp-servers/brave-search-mcp/package.json
+++ b/mcp-servers/brave-search-mcp/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [
     "mcp",

--- a/mcp-servers/brave-search-mcp/tests/server.test.js
+++ b/mcp-servers/brave-search-mcp/tests/server.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('startup checks', () => {
+  test('contains BRAVE_API_KEY', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/BRAVE_API_KEY/);
+  });
+});

--- a/mcp-servers/docker-mcp/package.json
+++ b/mcp-servers/docker-mcp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",

--- a/mcp-servers/docker-mcp/tests/server.test.js
+++ b/mcp-servers/docker-mcp/tests/server.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('startup checks', () => {
+  test('contains dockerode', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/dockerode/);
+  });
+});

--- a/mcp-servers/everything-mcp/package.json
+++ b/mcp-servers/everything-mcp/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [
     "mcp",

--- a/mcp-servers/everything-mcp/tests/server.test.js
+++ b/mcp-servers/everything-mcp/tests/server.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('startup checks', () => {
+  test('contains npx is not available', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/npx is not available/);
+  });
+});

--- a/mcp-servers/fetch-mcp/package.json
+++ b/mcp-servers/fetch-mcp/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [
     "mcp",

--- a/mcp-servers/fetch-mcp/tests/server.test.js
+++ b/mcp-servers/fetch-mcp/tests/server.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('startup checks', () => {
+  test('contains None of the required tools (uvx, docker, npx)', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/None of the required tools \(uvx, docker, npx\)/);
+  });
+});

--- a/mcp-servers/github-mcp/package.json
+++ b/mcp-servers/github-mcp/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
     "@composio/mcp": "^1.0.9"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }

--- a/mcp-servers/github-mcp/tests/server.test.js
+++ b/mcp-servers/github-mcp/tests/server.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('startup checks', () => {
+  test('contains GITHUB_PERSONAL_ACCESS_TOKEN', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/GITHUB_PERSONAL_ACCESS_TOKEN/);
+  });
+});

--- a/mcp-servers/memory-bank-mcp/package.json
+++ b/mcp-servers/memory-bank-mcp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",

--- a/mcp-servers/memory-bank-mcp/tests/server.test.js
+++ b/mcp-servers/memory-bank-mcp/tests/server.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('startup checks', () => {
+  test('contains MEMORY_FILE_PATH', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/MEMORY_FILE_PATH/);
+  });
+});

--- a/mcp-servers/notion-mcp/package.json
+++ b/mcp-servers/notion-mcp/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [
     "mcp",

--- a/mcp-servers/notion-mcp/tests/server.test.js
+++ b/mcp-servers/notion-mcp/tests/server.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('startup checks', () => {
+  test('contains NOTION_TOKEN', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/NOTION_TOKEN/);
+  });
+});

--- a/mcp-servers/postgres-mcp/package.json
+++ b/mcp-servers/postgres-mcp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",

--- a/mcp-servers/postgres-mcp/tests/server.test.js
+++ b/mcp-servers/postgres-mcp/tests/server.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('startup checks', () => {
+  test('contains connection-string', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/connection-string/);
+  });
+});

--- a/mcp-servers/puppeteer-mcp/package.json
+++ b/mcp-servers/puppeteer-mcp/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
     "puppeteer": "^24.16.0"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }

--- a/mcp-servers/puppeteer-mcp/tests/server.test.js
+++ b/mcp-servers/puppeteer-mcp/tests/server.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('startup checks', () => {
+  test('contains Launching browser', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/Launching browser/);
+  });
+});

--- a/mcp-servers/sequential-thinking-mcp/package.json
+++ b/mcp-servers/sequential-thinking-mcp/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [
     "mcp",

--- a/mcp-servers/sequential-thinking-mcp/tests/server.test.js
+++ b/mcp-servers/sequential-thinking-mcp/tests/server.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('startup checks', () => {
+  test('contains DISABLE_THOUGHT_LOGGING', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/DISABLE_THOUGHT_LOGGING/);
+  });
+});

--- a/mcp-servers/slack-mcp/package.json
+++ b/mcp-servers/slack-mcp/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [
     "mcp",

--- a/mcp-servers/slack-mcp/tests/server.test.js
+++ b/mcp-servers/slack-mcp/tests/server.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('startup checks', () => {
+  test('contains SLACK_MCP_XOXC_TOKEN', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/SLACK_MCP_XOXC_TOKEN/);
+  });
+});

--- a/mcp-servers/sourcegraph-mcp/package.json
+++ b/mcp-servers/sourcegraph-mcp/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",

--- a/mcp-servers/sourcegraph-mcp/tests/server.test.js
+++ b/mcp-servers/sourcegraph-mcp/tests/server.test.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('startup checks', () => {
+  test('contains SOURCEGRAPH_URL', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/SOURCEGRAPH_URL/);
+  });
+  test('contains SOURCEGRAPH_TOKEN', () => {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'index.js'), 'utf8');
+    expect(file).toMatch(/SOURCEGRAPH_TOKEN/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,5 +1,12 @@
 {
   "private": true,
-  "workspaces": ["mcp-servers/*"],
-  "devDependencies": {}
+  "workspaces": [
+    "mcp-servers/*"
+  ],
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "scripts": {
+    "test": "jest"
+  }
 }


### PR DESCRIPTION
## Summary
- add Jest-based startup checks for each MCP server
- set `test` script to run Jest across packages

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/jest)
- `npm test` (fails: jest: not found)

------
https://chatgpt.com/codex/tasks/task_e_68c61cb47de88326b4d01114315dd1b0